### PR TITLE
B11726 - 2 x n 타일링

### DIFF
--- a/algorithm/B11726.py
+++ b/algorithm/B11726.py
@@ -1,0 +1,17 @@
+import sys
+
+input=sys.stdin.readline
+
+n=int(input())
+
+dp=[0]*(n+1)
+dp[0]=0
+dp[1]=1
+dp[2]=2
+
+for i in range(3,n+1):
+    dp[i]=(dp[i-1]+dp[i-2])%10007
+
+# 2×n 크기의 직사각형을 채우는 방법의 수를 10,007로 나눈 나머지
+print(dp[n])
+


### PR DESCRIPTION
### ✅ 구현 명세
- dp =[0] *(n+1)으로 생성했었을 때 인덱스 런타임에러가 났었다. 
- dp =[0] *1001 (n의 최댓값이 1000) 으로 생성해주니 해결되었다. 

### 📚 참고
